### PR TITLE
Accept all new config

### DIFF
--- a/data/chroot.sh
+++ b/data/chroot.sh
@@ -15,6 +15,7 @@ apt-get dist-upgrade --yes
 
 # Install distribution packages
 apt-get install --yes \
+    -o Dpkg::Options::="--force-confnew" \
     pop-desktop-raspi
 
 # Clean apt caches


### PR DESCRIPTION
This should allow us to transition package config, and just have the newest config

Created because of:
```
Configuration file '/etc/apt/apt.conf.d/20apt-esm-hook.conf'
==> Deleted (by you or by a script) since installation.
==> Package distributor has shipped an updated version.
  What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
    D     : show the differences between the versions
    Z     : start a shell to examine the situation
```